### PR TITLE
Fix parallel DB dump table filters; clarify backup report for DB-only archives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A Laravel package for backing up databases and files to external sources with notifications",
     "type": "library",
     "license": "MIT",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "authors": [{
         "name": "Nathan Langer",
         "email": "nathanlanger@googlemail.com"

--- a/src/Database/DatabaseDumper.php
+++ b/src/Database/DatabaseDumper.php
@@ -233,19 +233,32 @@ class DatabaseDumper
         $configFile = $this->buildMysqlConfigFile($config, $dumpCommand);
         $safeFlags = implode(' ', $this->buildMysqlFlags());
         $tableArgs = $this->buildMysqlTableArgs($config['database']);
-        $extraFlags = $tableArgs['extraFlags'];
+        $extraFlags = trim($safeFlags . ' ' . $tableArgs['extraFlags']);
 
-        $allFlags = trim($safeFlags . ' ' . $extraFlags);
-
-        $command = sprintf(
-            '%s --defaults-extra-file=%s %s %s > %s 2>&1; rm %s',
-            $dumpCommand,
-            escapeshellarg($configFile),
-            $allFlags,
-            escapeshellarg($config['database']),
-            escapeshellarg($dumpPath),
-            escapeshellarg($configFile)
-        );
+        // Must match dumpMysql() / sequential path: include_tables / ignore-table / extra flags.
+        if ($tableArgs['useInclude']) {
+            $command = sprintf(
+                '%s --defaults-extra-file=%s %s %s %s > %s 2>&1; rm %s',
+                $dumpCommand,
+                escapeshellarg($configFile),
+                $extraFlags,
+                escapeshellarg($config['database']),
+                $tableArgs['tablesArg'],
+                escapeshellarg($dumpPath),
+                escapeshellarg($configFile)
+            );
+        } else {
+            $command = sprintf(
+                '%s --defaults-extra-file=%s %s %s %s > %s 2>&1; rm %s',
+                $dumpCommand,
+                escapeshellarg($configFile),
+                $extraFlags,
+                $tableArgs['ignoreFlags'],
+                escapeshellarg($config['database']),
+                escapeshellarg($dumpPath),
+                escapeshellarg($configFile)
+            );
+        }
 
         return proc_open($command, [], $pipes);
     }
@@ -339,14 +352,17 @@ class DatabaseDumper
     protected function startPostgresDumpProcess(array $config, string $dumpPath)
     {
         $pgpassFile = $this->buildPgpassFile($config);
+        $tableFlags = $this->buildPostgresTableFlags();
 
+        // Must match dumpPostgres(): same format and table include/exclude flags.
         $command = sprintf(
-            'PGPASSFILE=%s pg_dump --host=%s --port=%s --username=%s --dbname=%s > %s 2>&1; rm %s',
+            'PGPASSFILE=%s pg_dump --host=%s --port=%s --username=%s --dbname=%s --no-owner --no-privileges --format=plain %s > %s 2>&1; rm %s',
             escapeshellarg($pgpassFile),
             escapeshellarg($config['host']),
             escapeshellarg($config['port'] ?? 5432),
             escapeshellarg($config['username']),
             escapeshellarg($config['database']),
+            $tableFlags,
             escapeshellarg($dumpPath),
             escapeshellarg($pgpassFile)
         );

--- a/src/Support/BackupReport.php
+++ b/src/Support/BackupReport.php
@@ -36,6 +36,8 @@ class BackupReport
             $report['throughput'] = $metric->throughput_bytes_per_sec
                 ? Helpers::formatBytes((int) $metric->throughput_bytes_per_sec) . '/s'
                 : 'N/A';
+            // file_count is only from the file-backup step; DB + manifest are separate ZIP entries.
+            $report['files_backup_enabled'] = (bool) config('capsule.files.enabled', true);
         }
 
         $anomalies = $backupLog->metadata['anomalies'] ?? [];
@@ -79,6 +81,13 @@ class BackupReport
             $fileDesc = number_format($report['file_count']) . ' files';
             if ($report['directory_count'] > 0) {
                 $fileDesc .= " in {$report['directory_count']} dirs";
+            }
+            if (
+                $report['file_count'] === 0
+                && empty($report['files_backup_enabled'])
+                && ($report['db_dumps'] ?? 0) > 0
+            ) {
+                $fileDesc .= ' (file backup off; ZIP still has database/ + manifest.json)';
             }
             $rows[] = ['Files', $fileDesc];
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Parallel MySQL dumps** (`startMysqlDumpProcess`) did not pass `include_tables` / `ignore-table` / `mysqldump_flags` the same way as sequential `dumpMysql()`, so `--parallel` could dump the wrong scope compared to normal runs.
- **Parallel PostgreSQL dumps** (`startPostgresDumpProcess`) omitted `--no-owner --no-privileges --format=plain` and **all** `include_tables` / `exclude_tables` flags compared to `dumpPostgres()`.

## Report UX

When `files.enabled` is false and the DB backup ran, the summary showed `0 files`, which is easy to read as an empty ZIP. Metrics only count **file backup** entries; the archive still contains `database/*.sql` and `manifest.json`. The report now adds a short note in that case.

## Notes for the original issue

A **166 KB** archive with **1.87 MB** raw dump is normal (compressed SQL + manifest). **0 files** in the table means **no filesystem paths** were archived, not “ZIP is empty.”

If Archive Utility still says “unsupported format,” validate the file locally (`unzip -t`, `file backup.zip`) and run `php artisan capsule:backup --verify` — true 0-byte or corrupt uploads point to transport/storage, not the metrics line.

## Testing

PHP/composer were not available in the agent environment; syntax was reviewed manually. Please run the project test suite in CI or locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48dfd5de-a33c-43f4-b35c-18595b743e2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48dfd5de-a33c-43f4-b35c-18595b743e2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 2.0.1

* **New Features**
  * Added file backup status tracking and reporting in backup summaries

* **Bug Fixes**
  * Improved MySQL and PostgreSQL parallel dump command construction for better consistency with sequential dumps and proper flag handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->